### PR TITLE
Minor fix for empty trace parameters

### DIFF
--- a/tests/test_creation.py
+++ b/tests/test_creation.py
@@ -86,7 +86,7 @@ class TestCreation(unittest.TestCase):
 				Trace(
 					SampleCoding.FLOAT,
 					[get_sample(i) for i in range(0, sample_count)],
-					TraceParameterMap({'LEGACY_DATA': ByteArrayParameter(b'')})
+					TraceParameterMap()
 				)
 				for i in range(0, trace_count)
 			]

--- a/trsfile/engine/trs.py
+++ b/trsfile/engine/trs.py
@@ -320,7 +320,8 @@ class TrsEngine(Engine):
 			# Read (legacy) data
 			if Header.LENGTH_DATA in self.headers:
 				data = self.handle.read(self.headers[Header.LENGTH_DATA])
-				parameters['LEGACY_DATA'] = ByteArrayParameter(data)
+				if data:
+					parameters['LEGACY_DATA'] = ByteArrayParameter(data)
 		return parameters
 
 	def close(self):


### PR DESCRIPTION
Update the unit tests not to create an empty trace parameter and add a check in the trs engine on whether there is any data before adding it as legacy data parameter.