### PR TITLE
Update readthedocs config to not depend on requirements file.

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,5 +1,9 @@
-build:
-  image: latest
+version: 2
+
 python:
-  version: 3.6
-requirements_file: requirements-dev.txt
+  version: "3.8"
+  install:
+    - method: pip
+      path: .
+      extra_requirements:
+        - DEV


### PR DESCRIPTION
Installing the package with DEV extras should pull in all necessary dependencies.